### PR TITLE
Csra 429 e2e db

### DIFF
--- a/client/javascript/actions/index.js
+++ b/client/javascript/actions/index.js
@@ -84,9 +84,9 @@ export const saveHealthcareAssessmentAnswer = (key, value) => ({
   payload: { [key]: value },
 });
 
-export const completeRiskAssessmentFor = outcome => ({
+export const completeRiskAssessmentFor = ({ recommendation, nomisId, assessmentId }) => ({
   type: COMPLETE_RISK_ASSESSMENT,
-  payload: outcome,
+  payload: { recommendation, nomisId, assessmentId },
 });
 
 export const saveExitPoint = riskFactor => ({
@@ -96,14 +96,14 @@ export const saveExitPoint = riskFactor => ({
 
 export const clearExitPoint = () => ({ type: CLEAR_EXIT_POINT });
 
-export const completeHealthAssessmentFor = offender => ({
+export const completeHealthAssessmentFor = ({ nomisId, assessmentId }) => ({
   type: COMPLETE_HEALTH_ASSESSMENT,
-  payload: offender,
+  payload: { nomisId, assessmentId },
 });
 
-export const completeHealthAnswersFor = offender => ({
+export const completeHealthAnswersFor = ({ nomisId }) => ({
   type: HEALTHCARE_ANSWERS_COMPLETE,
-  payload: offender,
+  payload: { nomisId },
 });
 
 export const clearAnswers = nomisId => ({

--- a/client/javascript/pages/Dashboard.jsx
+++ b/client/javascript/pages/Dashboard.jsx
@@ -20,7 +20,7 @@ class Dashboard extends Component {
 
   renderProfiles() {
     return this.props.profiles.map(profile => (
-      <tr data-profile-row={profile.nomisId} key={profile.nomisId}>
+      <tr data-profile-row={profile.nomisId} key={profile.nomisId} data-profile-id={profile.assessmentCompleted.assessmentId}>
         <td>
           <span className="c-profile-holder" />
         </td>
@@ -104,7 +104,7 @@ class Dashboard extends Component {
                 </div>
               </div>
               <div className="c-date-title">
-                <h1 className="heading-large">
+                <h1 data-title="dashboard" className="heading-large">
                   <span className="heading-secondary">
                       Assessments on:
                     </span>

--- a/client/javascript/pages/Dashboard.jsx
+++ b/client/javascript/pages/Dashboard.jsx
@@ -20,7 +20,12 @@ class Dashboard extends Component {
 
   renderProfiles() {
     return this.props.profiles.map(profile => (
-      <tr data-profile-row={profile.nomisId} key={profile.nomisId} data-profile-id={profile.assessmentCompleted.assessmentId}>
+      <tr
+        data-profile-row={profile.nomisId}
+        key={profile.nomisId}
+        data-risk-assessment-id={profile.assessmentCompleted.assessmentId}
+        data-health-assessment-id={profile.healthAssessmentCompleted.assessmentId}
+      >
         <td>
           <span className="c-profile-holder" />
         </td>

--- a/client/javascript/pages/FullAssessmentOutcome.jsx
+++ b/client/javascript/pages/FullAssessmentOutcome.jsx
@@ -40,7 +40,7 @@ const FullAssessmentOutcome = ({
       <div>
         <div className="grid-row">
           <div className="column-two-thirds">
-            <h1 className="heading-xlarge">
+            <h1 data-title="full-outcome" className="heading-xlarge">
               Risk and healthcare assessment outcome
             </h1>
           </div>

--- a/client/javascript/pages/HealthcareSummary.jsx
+++ b/client/javascript/pages/HealthcareSummary.jsx
@@ -259,14 +259,14 @@ const mapStateToProps = (state, ownProps) => ({
 
 const mapActionsToProps = dispatch => ({
   onSubmit: ({ prisoner, riskAssessmentComplete, postData }) => {
-    postAssessmentToBackend('healthcare', postData);
-
-    dispatch(completeHealthAssessmentFor(prisoner));
-    if (riskAssessmentComplete) {
-      dispatch(replace(routes.FULL_ASSESSMENT_OUTCOME));
-    } else {
-      dispatch(replace(routes.DASHBOARD));
-    }
+    postAssessmentToBackend('healthcare', postData, (assessmentId) => {
+      dispatch(completeHealthAssessmentFor({ nomisId: prisoner.nomisId, assessmentId }));
+      if (riskAssessmentComplete) {
+        dispatch(replace(routes.FULL_ASSESSMENT_OUTCOME));
+      } else {
+        dispatch(replace(routes.DASHBOARD));
+      }
+    });
   },
   completeHealthAnswersFor: profile =>
     dispatch(completeHealthAnswersFor(profile)),

--- a/client/javascript/pages/RiskAssessmentSummary.jsx
+++ b/client/javascript/pages/RiskAssessmentSummary.jsx
@@ -171,14 +171,15 @@ const mapActionsToProps = dispatch => ({
       viperScore,
       questions,
       answers,
+    }, (assessmentId) => {
+      dispatch(completeRiskAssessmentFor({ recommendation: outcome, nomisId, assessmentId }));
+      if (healthcareAssessmentComplete) {
+        dispatch(replace(routes.FULL_ASSESSMENT_OUTCOME));
+      } else {
+        dispatch(replace(routes.DASHBOARD));
+      }
     });
 
-    dispatch(completeRiskAssessmentFor({ recommendation: outcome, nomisId }));
-    if (healthcareAssessmentComplete) {
-      dispatch(replace(routes.FULL_ASSESSMENT_OUTCOME));
-    } else {
-      dispatch(replace(routes.DASHBOARD));
-    }
   },
 });
 

--- a/client/javascript/pages/RiskAssessmentSummary.jsx
+++ b/client/javascript/pages/RiskAssessmentSummary.jsx
@@ -179,7 +179,6 @@ const mapActionsToProps = dispatch => ({
         dispatch(replace(routes.DASHBOARD));
       }
     });
-
   },
 });
 

--- a/client/javascript/services/buildAssessmentRequest.js
+++ b/client/javascript/services/buildAssessmentRequest.js
@@ -65,15 +65,6 @@ const buildQuestionAnswers = (questions, answers) =>
     };
   }, {});
 
-// Work around for outcome column too small
-const buildOutcome = (outcome) => {
-  if (outcome === 'shared cell with conditions') {
-    return 'shared with conditions';
-  }
-
-  return outcome;
-};
-
 const buildViperScore = (viperScore) => {
   if (viperScore) {
     return viperScore;
@@ -87,7 +78,7 @@ const buildAssessmentRequest = (
   { nomisId, outcome, viperScore, questions, answers },
 ) => ({
   nomisId,
-  outcome: buildOutcome(outcome),
+  outcome,
   type: assessmentType,
   viperScore: buildViperScore(viperScore),
   questions: buildQuestionAnswers(questions, answers),

--- a/client/javascript/services/postAssessmentToBackend.js
+++ b/client/javascript/services/postAssessmentToBackend.js
@@ -8,7 +8,7 @@ function postAssessmentToBackend(assessmentType, {
   viperScore,
   questions,
   answers,
-}) {
+}, callback) {
   const riskAssessmentRequestParams = buildAssessmentRequest(assessmentType, {
     nomisId,
     outcome,
@@ -21,15 +21,19 @@ function postAssessmentToBackend(assessmentType, {
    // eslint-disable-next-line no-console
   console.log('posting test data to endpoint: ', target);
    // eslint-disable-next-line no-console
-  console.log(
-    'request data is: ',
-    JSON.stringify(riskAssessmentRequestParams, null, 2),
+  console.log('request data is: ',  JSON.stringify(riskAssessmentRequestParams, null, 2),
   );
   post(target, riskAssessmentRequestParams, (err, res) => {
     // eslint-disable-next-line no-console
     console.log('response: ', JSON.stringify(res, null, 2));
-    // eslint-disable-next-line no-console
-    console.log('error: ', err);
+    console.log('ID: ', res.body.data.id);
+    if (err) {
+      // eslint-disable-next-line no-console
+      console.log('error: ', err);
+      callback(null);
+    } else {
+      callback(res.body.data.id);
+    }
   });
 }
 

--- a/client/javascript/services/postAssessmentToBackend.js
+++ b/client/javascript/services/postAssessmentToBackend.js
@@ -1,14 +1,14 @@
-import { post } from 'superagent';
+import superagent from 'superagent';
 
 import buildAssessmentRequest from './buildAssessmentRequest';
 
-function postAssessmentToBackend(assessmentType, {
+const postAssessmentToBackend = (assessmentType, {
   nomisId,
   outcome,
   viperScore,
   questions,
   answers,
-}, callback) {
+}, callback) => {
   const riskAssessmentRequestParams = buildAssessmentRequest(assessmentType, {
     nomisId,
     outcome,
@@ -16,25 +16,15 @@ function postAssessmentToBackend(assessmentType, {
     questions,
     answers,
   });
-
   const target = `${window.location.origin}/api/assessment`;
-   // eslint-disable-next-line no-console
-  console.log('posting test data to endpoint: ', target);
-   // eslint-disable-next-line no-console
-  console.log('request data is: ',  JSON.stringify(riskAssessmentRequestParams, null, 2),
-  );
-  post(target, riskAssessmentRequestParams, (err, res) => {
-    // eslint-disable-next-line no-console
-    console.log('response: ', JSON.stringify(res, null, 2));
-    console.log('ID: ', res.body.data.id);
-    if (err) {
-      // eslint-disable-next-line no-console
-      console.log('error: ', err);
+
+  superagent.post(target, riskAssessmentRequestParams, (error, res) => {
+    if (error) {
       callback(null);
     } else {
       callback(res.body.data.id);
     }
   });
-}
+};
 
 export default postAssessmentToBackend;

--- a/migrations/20170619153242_increase-outcome-column-width.js
+++ b/migrations/20170619153242_increase-outcome-column-width.js
@@ -1,0 +1,14 @@
+
+exports.up = knex => Promise.all([
+  knex('assessments').update('viper', 0),
+  knex.schema.table('assessments', (table) => {
+    table.string('outcome', 27).notNullable().alter();
+  }),
+]);
+
+exports.down = knex => Promise.all([
+  knex('assessments').update('viper', 0),
+  knex.schema.table('assessments', (table) => {
+    table.string('outcome', 25).notNullable().alter();
+  }),
+]);

--- a/migrations/20170619153242_increase-outcome-column-width.js
+++ b/migrations/20170619153242_increase-outcome-column-width.js
@@ -1,13 +1,11 @@
 
 exports.up = knex => Promise.all([
-  knex('assessments').update('viper', 0),
   knex.schema.table('assessments', (table) => {
     table.string('outcome', 27).notNullable().alter();
   }),
 ]);
 
 exports.down = knex => Promise.all([
-  knex('assessments').update('viper', 0),
   knex.schema.table('assessments', (table) => {
     table.string('outcome', 25).notNullable().alter();
   }),

--- a/server/app.js
+++ b/server/app.js
@@ -9,7 +9,7 @@ import createHealthRoute from './routes/health';
 import createAssessmentRoute from './routes/assessment';
 import index from './routes/index';
 
-export default function createApp(db, appInfo, assessment) {
+export default function createApp(db, appInfo, assessmentService) {
   const app = express();
 
   app.use(json());
@@ -19,7 +19,7 @@ export default function createApp(db, appInfo, assessment) {
   app.use(express.static(path.join(__dirname, '..', 'public')));
 
   app.use('/health', createHealthRoute(db, appInfo));
-  app.use('/api/assessment', createAssessmentRoute(assessment));
+  app.use('/api/assessment', createAssessmentRoute(assessmentService));
   app.use('/', index);
 
   // catch 404 and forward to error handler

--- a/server/index.js
+++ b/server/index.js
@@ -9,7 +9,7 @@ const buildInfo = config.dev ? null : require('../build-info.json');
 
 const db = createDB();
 const appInfo = createAppInfoService(buildInfo);
-const assessment = createAssessmentService(db, appInfo);
-const app = createApp(db, appInfo, assessment);
+const assessmentService = createAssessmentService(db, appInfo);
+const app = createApp(db, appInfo, assessmentService);
 
 export default app;

--- a/server/services/assessment.js
+++ b/server/services/assessment.js
@@ -2,7 +2,7 @@ import Joi from 'joi';
 
 const schema = Joi.object({
   type: Joi.string().valid('risk', 'healthcare'),
-  outcome: Joi.string().valid('single cell', 'shared cell', 'shared with conditions'),
+  outcome: Joi.string().valid('single cell', 'shared cell', 'shared cell with conditions'),
   nomisId: Joi.string().max(10),
   viperScore: Joi.number().optional()
     .min(-1).max(1)

--- a/test/client/unit/actions/index.spec.js
+++ b/test/client/unit/actions/index.spec.js
@@ -170,8 +170,7 @@ describe('Actions', () => {
       const outcome = {
         nomisId: 'foo-id',
         recommendation: 'foo-recommendation',
-        rating: 'foo-rating',
-        reasons: ['foo-reason'],
+        assessmentId: 'foo-nomis-id',
       };
       expect(completeRiskAssessmentFor(outcome)).to.eql({
         type: 'COMPLETE_RISK_ASSESSMENT',
@@ -183,10 +182,7 @@ describe('Actions', () => {
   describe('#completeHealthAnswersFor', () => {
     it('returns a HEALTHCARE_ANSWERS_COMPLETE action', () => {
       const offender = {
-        nomisId: 'AA12345',
-        surname: 'bar',
-        firstName: 'foo',
-        dob: '01-10-1997',
+        nomisId: 'foo-nomis-id',
       };
       expect(completeHealthAnswersFor(offender)).to.eql({
         type: 'HEALTHCARE_ANSWERS_COMPLETE',

--- a/test/client/unit/pages/HealthcareSummary.spec.js
+++ b/test/client/unit/pages/HealthcareSummary.spec.js
@@ -237,6 +237,23 @@ describe('<HealthcareSummary />', () => {
         }),
       ).to.equal(true, 'Changed path to /dashboard');
     });
+
+    it('marks the assessment as complete on submission', () => {
+      const wrapper = mount(
+        <Provider store={store}>
+          <HealthcareSummary />
+        </Provider>,
+      );
+
+      wrapper.find('[data-summary-next-steps] button').simulate('click');
+
+      expect(
+        store.dispatch.calledWithMatch({
+          type: 'COMPLETE_HEALTH_ASSESSMENT',
+          payload: { nomisId: 'foo-nomis-id', assessmentId: 123 },
+        }),
+      ).to.equal(true, 'triggered complete assessment');
+    });
   });
 
   context('when the risk assessment is complete', () => {

--- a/test/client/unit/pages/HealthcareSummary.spec.js
+++ b/test/client/unit/pages/HealthcareSummary.spec.js
@@ -1,6 +1,8 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
+import superagent from 'superagent';
+
 
 import { fakeStore } from '../test-helpers';
 
@@ -69,6 +71,15 @@ const storeData = {
 };
 
 describe('<HealthcareSummary />', () => {
+  let postStub;
+  before(() => {
+    postStub = sinon.stub(superagent, 'post');
+    postStub.yields(null, { body: { data: { id: 123 } } });
+  });
+  after(() => {
+    postStub.restore();
+  });
+
   context('Connected HealthcareSummary', () => {
     it('accepts and correctly renders a prisoner`s details', () => {
       const store = fakeStore(storeData);

--- a/test/client/unit/pages/RiskAssessmentSummary.spec.js
+++ b/test/client/unit/pages/RiskAssessmentSummary.spec.js
@@ -250,7 +250,7 @@ describe('<RiskAssessmentSummary />', () => {
         expect(
           store.dispatch.calledWithMatch({
             type: 'COMPLETE_RISK_ASSESSMENT',
-            payload: { recommendation: 'shared cell', nomisId: 'foo-nomis-id' },
+            payload: { recommendation: 'shared cell', nomisId: 'foo-nomis-id', assessmentId: 123 },
           }),
         ).to.equal(true, 'triggered complete assessment');
       });

--- a/test/client/unit/pages/RiskAssessmentSummary.spec.js
+++ b/test/client/unit/pages/RiskAssessmentSummary.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { Provider } from 'react-redux';
 import { mount } from 'enzyme';
+import superagent from 'superagent';
 
 import { fakeStore } from '../test-helpers';
 
@@ -41,6 +42,15 @@ const riskAssessmentAnswers = {
 };
 
 describe('<RiskAssessmentSummary />', () => {
+  let postStub;
+  before(() => {
+    postStub = sinon.stub(superagent, 'post');
+    postStub.yields(null, { body: { data: { id: 123 } } });
+  });
+  after(() => {
+    postStub.restore();
+  });
+
   context('Connected RiskAssessmentSummary', () => {
     const state = {
       answers: {

--- a/test/client/unit/services/cellAssignment.spec.js
+++ b/test/client/unit/services/cellAssignment.spec.js
@@ -45,7 +45,7 @@ describe('#Full assessment Decision engine', () => {
     });
   });
 
-  context('when the risk assessment outcome is shared with conditions', () => {
+  context('when the risk assessment outcome is shared cell with conditions', () => {
     context('and the outcome of both assessments are a variation of shared cell', () => {
       it('returns the outcome of a both assessments are as shared cell with conditions', () => {
         expect(

--- a/test/client/unit/services/postAssessmentToBackend.spec.js
+++ b/test/client/unit/services/postAssessmentToBackend.spec.js
@@ -1,0 +1,96 @@
+import superagent from 'superagent';
+
+import postAssessmentToBackend
+  from '../../../../client/javascript/services/postAssessmentToBackend';
+
+const postParams = {
+  nomisId: 'foo-nomis-id',
+  outcome: 'foo-outcome',
+  viperScore: 0.1,
+  questions: [
+    {
+      section: 'foo-section',
+      title: 'foo-title',
+      sharedCellPredicate: {
+        type: 'QUESTION',
+        value: 'no',
+        dependents: ['foo-section'],
+        reasons: [],
+      },
+    },
+    {
+      title: 'bar-title',
+      section: 'bar-section',
+      sharedCellPredicate: {
+        type: 'QUESTION',
+        value: 'no',
+        dependents: ['bar-section'],
+        reasons: ['bar-reason'],
+      },
+    },
+  ],
+  answers: {
+    'foo-section': {
+      answer: 'no',
+    },
+    'bar-section': {
+      answer: 'no',
+    },
+  },
+};
+
+const postData = {
+  nomisId: 'foo-nomis-id',
+  outcome: 'foo-outcome',
+  type: 'foo',
+  viperScore: 0.1,
+  questions: {
+    'foo-section': {
+      question: 'foo-title',
+      question_id: 'foo-section',
+      answer: 'no',
+    },
+    'bar-section': {
+      question: 'bar-title',
+      question_id: 'bar-section',
+      answer: 'no',
+    },
+  },
+  reasons: [],
+};
+
+describe('#postAssessmentToBackend', () => {
+  let postStub;
+  before(() => {
+    postStub = sinon.stub(superagent, 'post');
+  });
+  after(() => {
+    postStub.restore();
+  });
+
+  it('makes a POST request to /api/assessment', () => {
+    const callback = sinon.spy();
+    const response = { body: { data: { id: 123 } } };
+
+    postStub.yields(null, response);
+
+    postAssessmentToBackend('foo', postParams, callback);
+
+    expect(postStub.lastCall.args[0]).to.match(/\/api\/assessment/);
+    expect(postStub.lastCall.args[1]).to.eql(postData);
+
+    expect(callback.calledOnce).to.equal(true);
+    expect(callback.calledWithMatch(123)).to.equal(true, 'callback called with the correct');
+  });
+
+  it('handles failed responses', () => {
+    const callback = sinon.spy();
+    const response = { error: 'foo error' };
+
+    postStub.yields(new Error('foo'), response);
+    postAssessmentToBackend('foo', postParams, callback);
+
+    expect(callback.calledOnce).to.equal(true);
+    expect(callback.calledWithMatch(null)).to.equal(true, 'callback called with the correct');
+  });
+});

--- a/test/end-to-end/browser/both.assessments.shared.cell.outcome.spec.js
+++ b/test/end-to-end/browser/both.assessments.shared.cell.outcome.spec.js
@@ -1,7 +1,7 @@
 import AdminPage from './pages/Admin.page';
-import { thenTheAssessmentIsCompleted, whenALowRiskPrisonerIsAssessed } from './tasks/lowRiskPrisonerAssessed.task';
-import { givenThatTheOfficerIsSignedIn } from './tasks/officerSignsIn.task';
-import { whenHealthcareRecommendsSharedCell } from './tasks/prisonersHealthcareResultsAreEntered.task';
+import {thenTheAssessmentIsCompleted, whenALowRiskPrisonerIsAssessed} from './tasks/lowRiskPrisonerAssessed.task';
+import {givenThatTheOfficerIsSignedIn} from './tasks/officerSignsIn.task';
+import {whenHealthcareRecommendsSharedCell} from './tasks/prisonersHealthcareResultsAreEntered.task';
 import HealthcareSummary from './pages/healthcare/HealthcareSummary.page';
 import FullAssessmentOutcomePage from './pages/FullAssessmentOutcome.page';
 import FullAssessmentCompletePage from './pages/FullAssessmentComplete.page';
@@ -32,11 +32,13 @@ describe('Both assessments (Shared cell outcome)', () => {
     expect(row.getText()).to.equalIgnoreCase('John Lowe J1234LO 01-Oct-1970 Complete Complete Shared Cell');
   }
 
-  it('Assesses a low risk prisoner', () => {
-    givenThatTheOfficerIsSignedIn();
-    whenALowRiskPrisonerIsAssessed();
-    thenTheAssessmentIsCompleted();
-    whenHealthcareRecommendsSharedCell();
-    thenTheFullAssessmentIsCompleted();
+  it('Assesses a low risk prisoner', async function () {
+    return new Promise((resolve) => {
+      givenThatTheOfficerIsSignedIn();
+      whenALowRiskPrisonerIsAssessed();
+      thenTheAssessmentIsCompleted(resolve);
+      whenHealthcareRecommendsSharedCell();
+      thenTheFullAssessmentIsCompleted();
+    });
   });
 });

--- a/test/end-to-end/browser/both.assessments.shared.cell.outcome.spec.js
+++ b/test/end-to-end/browser/both.assessments.shared.cell.outcome.spec.js
@@ -1,7 +1,7 @@
 import AdminPage from './pages/Admin.page';
-import {thenTheAssessmentIsCompleted, whenALowRiskPrisonerIsAssessed} from './tasks/lowRiskPrisonerAssessed.task';
-import {givenThatTheOfficerIsSignedIn} from './tasks/officerSignsIn.task';
-import {whenHealthcareRecommendsSharedCell} from './tasks/prisonersHealthcareResultsAreEntered.task';
+import { thenTheAssessmentIsCompleted, whenALowRiskPrisonerIsAssessed } from './tasks/lowRiskPrisonerAssessed.task';
+import { givenThatTheOfficerIsSignedIn } from './tasks/officerSignsIn.task';
+import { whenHealthcareRecommendsSharedCell } from './tasks/prisonersHealthcareResultsAreEntered.task';
 import HealthcareSummary from './pages/healthcare/HealthcareSummary.page';
 import FullAssessmentOutcomePage from './pages/FullAssessmentOutcome.page';
 import FullAssessmentCompletePage from './pages/FullAssessmentComplete.page';
@@ -16,7 +16,9 @@ describe('Both assessments (Shared cell outcome)', () => {
 
   function thenTheFullAssessmentIsCompleted() {
     HealthcareSummary.clickContinue();
-    expect(FullAssessmentOutcomePage.mainHeading).to.equal('Risk and healthcare assessment outcome');
+    expect(FullAssessmentOutcomePage.waitForMainHeadingWithDataId('full-outcome')).to.equal(
+      'Risk and healthcare assessment outcome',
+    );
     expect(FullAssessmentOutcomePage.name).to.equalIgnoreCase('John Lowe');
     expect(FullAssessmentOutcomePage.dob).to.equalIgnoreCase('01-Oct-1970');
     expect(FullAssessmentOutcomePage.nomisId).to.equalIgnoreCase('J1234LO');
@@ -32,13 +34,11 @@ describe('Both assessments (Shared cell outcome)', () => {
     expect(row.getText()).to.equalIgnoreCase('John Lowe J1234LO 01-Oct-1970 Complete Complete Shared Cell');
   }
 
-  it('Assesses a low risk prisoner', async function () {
-    return new Promise((resolve) => {
-      givenThatTheOfficerIsSignedIn();
-      whenALowRiskPrisonerIsAssessed();
-      thenTheAssessmentIsCompleted(resolve, 'shared cell');
-      whenHealthcareRecommendsSharedCell();
-      thenTheFullAssessmentIsCompleted();
-    });
-  });
+  it('Assesses a low risk prisoner', async () => new Promise((resolve, reject) => {
+    givenThatTheOfficerIsSignedIn();
+    whenALowRiskPrisonerIsAssessed();
+    thenTheAssessmentIsCompleted({ resolve, reject, sharedText: 'shared cell' });
+    whenHealthcareRecommendsSharedCell();
+    thenTheFullAssessmentIsCompleted();
+  }));
 });

--- a/test/end-to-end/browser/both.assessments.shared.cell.outcome.spec.js
+++ b/test/end-to-end/browser/both.assessments.shared.cell.outcome.spec.js
@@ -36,7 +36,7 @@ describe('Both assessments (Shared cell outcome)', () => {
     return new Promise((resolve) => {
       givenThatTheOfficerIsSignedIn();
       whenALowRiskPrisonerIsAssessed();
-      thenTheAssessmentIsCompleted(resolve);
+      thenTheAssessmentIsCompleted(resolve, 'shared cell');
       whenHealthcareRecommendsSharedCell();
       thenTheFullAssessmentIsCompleted();
     });

--- a/test/end-to-end/browser/both.assessments.single.cell.outcome.spec.js
+++ b/test/end-to-end/browser/both.assessments.single.cell.outcome.spec.js
@@ -1,5 +1,5 @@
 import AdminPage from './pages/Admin.page';
-import { givenThatTheOfficerIsSignedIn } from './tasks/officerSignsIn.task';
+import {givenThatTheOfficerIsSignedIn} from './tasks/officerSignsIn.task';
 import {
   whenHealthcareRecommendsSharedCell,
   whenHealthcareRecommendsSingleCell,
@@ -14,7 +14,7 @@ import {
 } from './tasks/vulnerablePrisonerAssessed.task';
 import {
   whenALowRiskPrisonerIsAssessed,
-  thenTheAssessmentIsCompleted as thenHealthcareAssessmentIsComplete,
+  thenTheAssessmentIsCompleted,
 } from './tasks/lowRiskPrisonerAssessed.task';
 
 describe('Both assessments (Single cell outcome)', () => {
@@ -30,10 +30,10 @@ describe('Both assessments (Single cell outcome)', () => {
   });
 
   function thenTheFullAssessmentIsCompletedWith({
-    riskRecommendation,
-    healthRecommendation,
-    finalRecommendation,
-  }) {
+                                                  riskRecommendation,
+                                                  healthRecommendation,
+                                                  finalRecommendation,
+                                                }) {
     HealthcareSummary.clickContinue();
     expect(FullAssessmentOutcomePage.mainHeading).to.equal(
       'Risk and healthcare assessment outcome',
@@ -62,27 +62,31 @@ describe('Both assessments (Single cell outcome)', () => {
     );
   }
 
-  it('Assesses a vulnerable prisoner', () => {
-    givenThatTheOfficerIsSignedIn();
-    whenAVulnerablePrisonerIsAssessed();
-    thenRiskAssessmentIsComplete();
-    whenHealthcareRecommendsSharedCell();
-    thenTheFullAssessmentIsCompletedWith({
-      riskRecommendation: 'single',
-      healthRecommendation: 'shared',
-      finalRecommendation: 'single',
+  it('Assesses a vulnerable prisoner', async function () {
+    return new Promise((resolve) => {
+      givenThatTheOfficerIsSignedIn();
+      whenAVulnerablePrisonerIsAssessed();
+      thenRiskAssessmentIsComplete(resolve);
+      whenHealthcareRecommendsSharedCell();
+      thenTheFullAssessmentIsCompletedWith({
+        riskRecommendation: 'single',
+        healthRecommendation: 'shared',
+        finalRecommendation: 'single',
+      });
     });
   });
 
-  it('Assesses a prisoner that healthcare deem as a risk', () => {
-    givenThatTheOfficerIsSignedIn();
-    whenALowRiskPrisonerIsAssessed();
-    thenHealthcareAssessmentIsComplete();
-    whenHealthcareRecommendsSingleCell();
-    thenTheFullAssessmentIsCompletedWith({
-      riskRecommendation: 'shared',
-      healthRecommendation: 'single',
-      finalRecommendation: 'single',
+  it('Assesses a prisoner that healthcare deem as a risk', async function () {
+    return new Promise((resolve) => {
+      givenThatTheOfficerIsSignedIn();
+      whenALowRiskPrisonerIsAssessed();
+      thenTheAssessmentIsCompleted(resolve);
+      whenHealthcareRecommendsSingleCell();
+      thenTheFullAssessmentIsCompletedWith({
+        riskRecommendation: 'shared',
+        healthRecommendation: 'single',
+        finalRecommendation: 'single',
+      });
     });
   });
 });

--- a/test/end-to-end/browser/both.assessments.single.cell.outcome.spec.js
+++ b/test/end-to-end/browser/both.assessments.single.cell.outcome.spec.js
@@ -1,5 +1,5 @@
 import AdminPage from './pages/Admin.page';
-import {givenThatTheOfficerIsSignedIn} from './tasks/officerSignsIn.task';
+import { givenThatTheOfficerIsSignedIn } from './tasks/officerSignsIn.task';
 import {
   whenHealthcareRecommendsSharedCell,
   whenHealthcareRecommendsSingleCell,
@@ -30,12 +30,13 @@ describe('Both assessments (Single cell outcome)', () => {
   });
 
   function thenTheFullAssessmentIsCompletedWith({
-                                                  riskRecommendation,
-                                                  healthRecommendation,
-                                                  finalRecommendation,
-                                                }) {
+    riskRecommendation,
+    healthRecommendation,
+    finalRecommendation,
+  }) {
     HealthcareSummary.clickContinue();
-    expect(FullAssessmentOutcomePage.mainHeading).to.equal(
+
+    expect(FullAssessmentOutcomePage.waitForMainHeadingWithDataId('full-outcome')).to.equal(
       'Risk and healthcare assessment outcome',
     );
     expect(FullAssessmentOutcomePage.name).to.equalIgnoreCase('John Lowe');
@@ -62,31 +63,27 @@ describe('Both assessments (Single cell outcome)', () => {
     );
   }
 
-  it('Assesses a vulnerable prisoner', async function () {
-    return new Promise((resolve) => {
-      givenThatTheOfficerIsSignedIn();
-      whenAVulnerablePrisonerIsAssessed();
-      thenRiskAssessmentIsComplete(resolve);
-      whenHealthcareRecommendsSharedCell();
-      thenTheFullAssessmentIsCompletedWith({
-        riskRecommendation: 'single',
-        healthRecommendation: 'shared',
-        finalRecommendation: 'single',
-      });
+  it('Assesses a vulnerable prisoner', async () => new Promise((resolve, reject) => {
+    givenThatTheOfficerIsSignedIn();
+    whenAVulnerablePrisonerIsAssessed();
+    thenRiskAssessmentIsComplete({ resolve, reject });
+    whenHealthcareRecommendsSharedCell();
+    thenTheFullAssessmentIsCompletedWith({
+      riskRecommendation: 'single',
+      healthRecommendation: 'shared',
+      finalRecommendation: 'single',
     });
-  });
+  }));
 
-  it('Assesses a prisoner that healthcare deem as a risk', async function () {
-    return new Promise((resolve) => {
-      givenThatTheOfficerIsSignedIn();
-      whenALowRiskPrisonerIsAssessed();
-      thenTheAssessmentIsCompleted(resolve, 'shared cell');
-      whenHealthcareRecommendsSingleCell();
-      thenTheFullAssessmentIsCompletedWith({
-        riskRecommendation: 'shared',
-        healthRecommendation: 'single',
-        finalRecommendation: 'single',
-      });
+  it('Assesses a prisoner that healthcare deem as a risk', async () => new Promise((resolve, reject) => {
+    givenThatTheOfficerIsSignedIn();
+    whenALowRiskPrisonerIsAssessed();
+    thenTheAssessmentIsCompleted({ resolve, reject, sharedText: 'shared cell' });
+    whenHealthcareRecommendsSingleCell();
+    thenTheFullAssessmentIsCompletedWith({
+      riskRecommendation: 'shared',
+      healthRecommendation: 'single',
+      finalRecommendation: 'single',
     });
-  });
+  }));
 });

--- a/test/end-to-end/browser/both.assessments.single.cell.outcome.spec.js
+++ b/test/end-to-end/browser/both.assessments.single.cell.outcome.spec.js
@@ -80,7 +80,7 @@ describe('Both assessments (Single cell outcome)', () => {
     return new Promise((resolve) => {
       givenThatTheOfficerIsSignedIn();
       whenALowRiskPrisonerIsAssessed();
-      thenTheAssessmentIsCompleted(resolve);
+      thenTheAssessmentIsCompleted(resolve, 'shared cell');
       whenHealthcareRecommendsSingleCell();
       thenTheFullAssessmentIsCompletedWith({
         riskRecommendation: 'shared',

--- a/test/end-to-end/browser/db/dbAssertions.js
+++ b/test/end-to-end/browser/db/dbAssertions.js
@@ -1,6 +1,6 @@
 import db from '../../../util/db';
 
-function checkLowRiskValuesWhereWrittenToDatabase(resolve, assessmentId, questionData, sharedText) {
+function checkLowRiskValuesWhereWrittenToDatabase(resolve, assessmentId, questionData, reasons, sharedText) {
   db.select().table('assessments').where('assessment_id', Number(assessmentId)).then(
     (result) => {
       expect(result[0].nomis_id).to.equal('J1234LO');
@@ -9,10 +9,11 @@ function checkLowRiskValuesWhereWrittenToDatabase(resolve, assessmentId, questio
       expect(result[0].git_version).to.not.equal(undefined, 'expected a git_version');
       expect(result[0].git_date).to.not.equal(undefined, 'expected a git_date');
       expect(result[0].type).to.equal('risk');
-      expect(result[0].outcome).to.equal(sharedText);
-      expect(result[0].reasons).to.equal('[]');
-      console.log(result[0].questions);
-      expect(JSON.parse(result[0].questions)).to.eql(questionData);
+      expect(result[0].outcome).to.equal(sharedText || 'single cell');
+      expect(result[0].reasons).to.equal(reasons || '[]');
+      console.log('thing1: ', result[0].questions);
+      console.log('thing2: ', questionData);
+      // expect(JSON.parse(result[0].questions)).to.eql(questionData);
       expect(result[0].viper).to.equal(0.35);
       resolve();
     });

--- a/test/end-to-end/browser/db/dbAssertions.js
+++ b/test/end-to-end/browser/db/dbAssertions.js
@@ -1,0 +1,22 @@
+import db from '../../../util/db';
+
+function checkLowRiskValuesWhereWrittenToDatabase(resolve, assessmentId, questionData, sharedText) {
+  db.select().table('assessments').where('assessment_id', Number(assessmentId)).then(
+    (result) => {
+      expect(result[0].nomis_id).to.equal('J1234LO');
+      expect(result[0].timestamp).to.not.equal(undefined, 'expected a timestamp');
+      expect(result[0].questions_hash).to.not.equal(undefined, 'expected a questions_hash');
+      expect(result[0].git_version).to.not.equal(undefined, 'expected a git_version');
+      expect(result[0].git_date).to.not.equal(undefined, 'expected a git_date');
+      expect(result[0].type).to.equal('risk');
+      expect(result[0].outcome).to.equal(sharedText);
+      expect(result[0].reasons).to.equal('[]');
+      console.log(result[0].questions);
+      expect(JSON.parse(result[0].questions)).to.eql(questionData);
+      expect(result[0].viper).to.equal(0.35);
+      resolve();
+    });
+
+}
+
+export default checkLowRiskValuesWhereWrittenToDatabase;

--- a/test/end-to-end/browser/db/dbAssertions.js
+++ b/test/end-to-end/browser/db/dbAssertions.js
@@ -13,7 +13,7 @@ function checkLowRiskValuesWhereWrittenToDatabase(resolve, assessmentId, questio
       expect(result[0].reasons).to.equal(reasons || '[]');
       console.log('thing1: ', result[0].questions);
       console.log('thing2: ', questionData);
-      // expect(JSON.parse(result[0].questions)).to.eql(questionData);
+      expect(JSON.parse(result[0].questions)).to.eql(questionData);
       expect(result[0].viper).to.equal(0.35);
       resolve();
     });

--- a/test/end-to-end/browser/db/dbAssertions.js
+++ b/test/end-to-end/browser/db/dbAssertions.js
@@ -1,23 +1,41 @@
 import db from '../../../util/db';
 
-function checkLowRiskValuesWhereWrittenToDatabase(resolve, assessmentId, questionData, reasons, sharedText) {
-  db.select().table('assessments').where('assessment_id', Number(assessmentId)).then(
-    (result) => {
+const checkLowRiskValuesWhereWrittenToDatabase = ({
+  resolve,
+  reject,
+  assessmentType,
+  assessmentId,
+  questionData,
+  reasons,
+  sharedText,
+}) => {
+  db
+    .select()
+    .table('assessments')
+    .where('assessment_id', Number(assessmentId))
+    .then((result) => {
       expect(result[0].nomis_id).to.equal('J1234LO');
-      expect(result[0].timestamp).to.not.equal(undefined, 'expected a timestamp');
-      expect(result[0].questions_hash).to.not.equal(undefined, 'expected a questions_hash');
-      expect(result[0].git_version).to.not.equal(undefined, 'expected a git_version');
+      expect(result[0].timestamp).to.not.equal(
+        undefined,
+        'expected a timestamp',
+      );
+      expect(result[0].questions_hash).to.not.equal(
+        undefined,
+        'expected a questions_hash',
+      );
+      expect(result[0].git_version).to.not.equal(
+        undefined,
+        'expected a git_version',
+      );
       expect(result[0].git_date).to.not.equal(undefined, 'expected a git_date');
-      expect(result[0].type).to.equal('risk');
+      expect(result[0].type).to.equal(assessmentType || 'risk');
       expect(result[0].outcome).to.equal(sharedText || 'single cell');
       expect(result[0].reasons).to.equal(reasons || '[]');
-      console.log('thing1: ', result[0].questions);
-      console.log('thing2: ', questionData);
       expect(JSON.parse(result[0].questions)).to.eql(questionData);
       expect(result[0].viper).to.equal(0.35);
       resolve();
-    });
-
-}
+    })
+    .catch(error => reject(error));
+};
 
 export default checkLowRiskValuesWhereWrittenToDatabase;

--- a/test/end-to-end/browser/db/dbAssertions.js
+++ b/test/end-to-end/browser/db/dbAssertions.js
@@ -1,21 +1,22 @@
 import db from '../../../util/db';
 
-const checkLowRiskValuesWhereWrittenToDatabase = ({
+const checkThatAssessmentDataWasWrittenToDatabase = ({
   resolve,
   reject,
-  assessmentType,
+  nomisId,
+  assessmentType = 'risk',
   assessmentId,
   questionData,
-  reasons,
-  sharedText,
+  reasons = [],
+  sharedText = 'single cell',
 }) => {
   db
     .select()
     .table('assessments')
     .where('assessment_id', Number(assessmentId))
     .then((result) => {
-      expect(result[0].nomis_id).to.equal('J1234LO');
-      expect(result[0].timestamp).to.not.equal(
+      expect(result[0].nomis_id).to.equal(nomisId);
+      expect(result[0].timestamp).to.not.be.equal(
         undefined,
         'expected a timestamp',
       );
@@ -28,9 +29,9 @@ const checkLowRiskValuesWhereWrittenToDatabase = ({
         'expected a git_version',
       );
       expect(result[0].git_date).to.not.equal(undefined, 'expected a git_date');
-      expect(result[0].type).to.equal(assessmentType || 'risk');
-      expect(result[0].outcome).to.equal(sharedText || 'single cell');
-      expect(result[0].reasons).to.equal(reasons || '[]');
+      expect(result[0].type).to.equal(assessmentType);
+      expect(result[0].outcome).to.equal(sharedText);
+      expect(JSON.parse(result[0].reasons)).to.eql(reasons);
       expect(JSON.parse(result[0].questions)).to.eql(questionData);
       expect(result[0].viper).to.equal(0.35);
       resolve();
@@ -38,4 +39,4 @@ const checkLowRiskValuesWhereWrittenToDatabase = ({
     .catch(error => reject(error));
 };
 
-export default checkLowRiskValuesWhereWrittenToDatabase;
+export default checkThatAssessmentDataWasWrittenToDatabase;

--- a/test/end-to-end/browser/healthcare.assessment.spec.js
+++ b/test/end-to-end/browser/healthcare.assessment.spec.js
@@ -12,9 +12,9 @@ describe('Healthcare assessment', () => {
     AdminPage.loadTestUsers();
   });
 
-  it('Record a prisoner`s healthcare details', () => {
+  it('Record a prisoner`s healthcare details', async () => new Promise((resolve, reject) => {
     givenThatTheOfficerIsSignedIn();
     whenHealthcareRecommendsSharedCell();
-    thenTheHealthcareAssessmentIsComplete();
-  });
+    thenTheHealthcareAssessmentIsComplete({ resolve, reject, sharedText: 'shared cell' });
+  }));
 });

--- a/test/end-to-end/browser/pages/BasePage.js
+++ b/test/end-to-end/browser/pages/BasePage.js
@@ -2,6 +2,10 @@
 class BasePage {
 
   get mainHeading() { return browser.getText('h1'); }
+  waitForMainHeadingWithDataId(id) {
+    browser.waitForVisible(`[data-title="${id}"]`, 5000);
+    return browser.getText('h1');
+  }
   get form() { return browser.element('.form'); }
   get headerUsername() { return browser.getText('[data-header-username]'); }
 

--- a/test/end-to-end/browser/risk-assessment.shared.cell.outcome.spec.js
+++ b/test/end-to-end/browser/risk-assessment.shared.cell.outcome.spec.js
@@ -1,6 +1,7 @@
 import AdminPage from './pages/Admin.page';
 import { givenThatTheOfficerIsSignedIn } from './tasks/officerSignsIn.task';
 import { thenTheAssessmentIsCompleted, whenALowRiskPrisonerIsAssessed } from './tasks/lowRiskPrisonerAssessed.task';
+import db from '../../util/db';
 
 describe('Risk assessment (shared cell outcome)', () => {
   before(() => {
@@ -9,9 +10,11 @@ describe('Risk assessment (shared cell outcome)', () => {
     AdminPage.loadTestUsers();
   });
 
-  it('Assesses a low risk prisoner', () => {
-    givenThatTheOfficerIsSignedIn();
-    whenALowRiskPrisonerIsAssessed();
-    thenTheAssessmentIsCompleted();
+  it('Assesses a low risk prisoner', async function() {
+    return new Promise((resolve) => {
+      givenThatTheOfficerIsSignedIn();
+      whenALowRiskPrisonerIsAssessed();
+      thenTheAssessmentIsCompleted(resolve);
+    });
   });
 });

--- a/test/end-to-end/browser/risk-assessment.shared.cell.outcome.spec.js
+++ b/test/end-to-end/browser/risk-assessment.shared.cell.outcome.spec.js
@@ -10,7 +10,7 @@ describe('Risk assessment (shared cell outcome)', () => {
     AdminPage.loadTestUsers();
   });
 
-  it('Assesses a low risk prisoner', async function() {
+  it('Assesses a low risk prisoner', async function () {
     return new Promise((resolve) => {
       givenThatTheOfficerIsSignedIn();
       whenALowRiskPrisonerIsAssessed();

--- a/test/end-to-end/browser/risk-assessment.shared.cell.outcome.spec.js
+++ b/test/end-to-end/browser/risk-assessment.shared.cell.outcome.spec.js
@@ -1,7 +1,6 @@
 import AdminPage from './pages/Admin.page';
 import { givenThatTheOfficerIsSignedIn } from './tasks/officerSignsIn.task';
 import { thenTheAssessmentIsCompleted, whenALowRiskPrisonerIsAssessed } from './tasks/lowRiskPrisonerAssessed.task';
-import db from '../../util/db';
 
 describe('Risk assessment (shared cell outcome)', () => {
   before(() => {
@@ -10,11 +9,9 @@ describe('Risk assessment (shared cell outcome)', () => {
     AdminPage.loadTestUsers();
   });
 
-  it('Assesses a low risk prisoner', async function () {
-    return new Promise((resolve) => {
-      givenThatTheOfficerIsSignedIn();
-      whenALowRiskPrisonerIsAssessed();
-      thenTheAssessmentIsCompleted(resolve, 'shared cell');
-    });
-  });
+  it('Assesses a low risk prisoner', async () => new Promise((resolve, reject) => {
+    givenThatTheOfficerIsSignedIn();
+    whenALowRiskPrisonerIsAssessed();
+    thenTheAssessmentIsCompleted({ resolve, reject, sharedText: 'shared cell' });
+  }));
 });

--- a/test/end-to-end/browser/risk-assessment.shared.cell.outcome.spec.js
+++ b/test/end-to-end/browser/risk-assessment.shared.cell.outcome.spec.js
@@ -14,7 +14,7 @@ describe('Risk assessment (shared cell outcome)', () => {
     return new Promise((resolve) => {
       givenThatTheOfficerIsSignedIn();
       whenALowRiskPrisonerIsAssessed();
-      thenTheAssessmentIsCompleted(resolve);
+      thenTheAssessmentIsCompleted(resolve, 'shared cell');
     });
   });
 });

--- a/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
+++ b/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
@@ -16,9 +16,11 @@ describe('Risk assessment (shared cell outcome with conditions)', () => {
     browser.reload();
   });
 
-  it('Assesses a low risk prisoner who uses drugs', () => {
+  it('Assesses a low risk prisoner who uses drugs', async () => new Promise((resolve) => {
     givenThatTheOfficerIsSignedIn();
     whenALowRiskPrisonerWhoUsesDrugsIsAssessed();
-    thenTheAssessmentIsCompleted();
-  });
+    thenTheAssessmentIsCompleted(resolve,
+        'shared with conditions',
+        '[{"question_id":"drug-misuse","reason":"Has indicated drug use"}]');
+  }));
 });

--- a/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
+++ b/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
@@ -16,12 +16,14 @@ describe('Risk assessment (shared cell outcome with conditions)', () => {
     browser.reload();
   });
 
-  it('Assesses a low risk prisoner who uses drugs', async () => new Promise((resolve) => {
+  it('Assesses a low risk prisoner who uses drugs', async () => new Promise((resolve, reject) => {
     givenThatTheOfficerIsSignedIn();
     whenALowRiskPrisonerWhoUsesDrugsIsAssessed();
-    thenTheAssessmentIsCompleted(resolve,
-        'shared with conditions',
-        '[{"question_id":"drug-misuse","reason":"Has indicated drug use"}]',
-        true);
+    thenTheAssessmentIsCompleted({
+      resolve,
+      reject,
+      sharedText: 'shared with conditions',
+      reasons: '[{"question_id":"drug-misuse","reason":"Has indicated drug use"}]',
+      hasUsedDrugs: true });
   }));
 });

--- a/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
+++ b/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
@@ -22,7 +22,7 @@ describe('Risk assessment (shared cell outcome with conditions)', () => {
     thenTheAssessmentIsCompleted({
       resolve,
       reject,
-      sharedText: 'shared with conditions',
+      sharedText: 'shared cell with conditions',
       reasons: '[{"question_id":"drug-misuse","reason":"Has indicated drug use"}]',
       hasUsedDrugs: true });
   }));

--- a/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
+++ b/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
@@ -16,14 +16,18 @@ describe('Risk assessment (shared cell outcome with conditions)', () => {
     browser.reload();
   });
 
-  it('Assesses a low risk prisoner who uses drugs', async () => new Promise((resolve, reject) => {
-    givenThatTheOfficerIsSignedIn();
-    whenALowRiskPrisonerWhoUsesDrugsIsAssessed();
-    thenTheAssessmentIsCompleted({
-      resolve,
-      reject,
-      sharedText: 'shared cell with conditions',
-      reasons: '[{"question_id":"drug-misuse","reason":"Has indicated drug use"}]',
-      hasUsedDrugs: true });
-  }));
+  it('Assesses a low risk prisoner who uses drugs', async () =>
+    new Promise((resolve, reject) => {
+      givenThatTheOfficerIsSignedIn();
+      whenALowRiskPrisonerWhoUsesDrugsIsAssessed();
+      thenTheAssessmentIsCompleted({
+        resolve,
+        reject,
+        sharedText: 'shared cell with conditions',
+        reasons: [
+          { question_id: 'drug-misuse', reason: 'Has indicated drug use' },
+        ],
+        hasUsedDrugs: true,
+      });
+    }));
 });

--- a/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
+++ b/test/end-to-end/browser/risk-assessment.shared.cell.outcome.with.conditions.spec.js
@@ -21,6 +21,7 @@ describe('Risk assessment (shared cell outcome with conditions)', () => {
     whenALowRiskPrisonerWhoUsesDrugsIsAssessed();
     thenTheAssessmentIsCompleted(resolve,
         'shared with conditions',
-        '[{"question_id":"drug-misuse","reason":"Has indicated drug use"}]');
+        '[{"question_id":"drug-misuse","reason":"Has indicated drug use"}]',
+        true);
   }));
 });

--- a/test/end-to-end/browser/risk-assessment.single.cell.outcome.high.viper.spec.js
+++ b/test/end-to-end/browser/risk-assessment.single.cell.outcome.high.viper.spec.js
@@ -4,7 +4,7 @@ import { givenThatTheOfficerIsSignedIn } from './tasks/officerSignsIn.task';
 import whenAViolentPrisonerIsAssessed from './tasks/violentPrisonerAssessed.task';
 
 function thenTheAssessmentIsCompleted() {
-  expect(DashboardPage.mainHeading).to.contain('Assessments on:');
+  expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=I9876RA]');
   expect(row.getText()).to.equal('Ian Rate I9876RA 23-Mar-1988 Complete Start');
 }

--- a/test/end-to-end/browser/risk-assessment.single.cell.outcome.no.viper.spec.js
+++ b/test/end-to-end/browser/risk-assessment.single.cell.outcome.no.viper.spec.js
@@ -4,7 +4,7 @@ import { givenThatTheOfficerIsSignedIn } from './tasks/officerSignsIn.task';
 import whenAPrisonerWithNoViperIsAssessed from './tasks/prisonerWithNoViperIsAssessed.task';
 
 function thenTheAssessmentIsCompleted() {
-  expect(DashboardPage.mainHeading).to.contain('Assessments on:');
+  expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J6285NE]');
   expect(row.getText()).to.equal('James Neo J6285NE 03-Dec-1958 Complete Start');
 }

--- a/test/end-to-end/browser/risk-assessment.single.cell.outcome.vulnerable.spec.js
+++ b/test/end-to-end/browser/risk-assessment.single.cell.outcome.vulnerable.spec.js
@@ -9,9 +9,11 @@ describe('Risk assessment for a vulnerable prisoner (single cell outcome)', () =
     AdminPage.loadTestUsers();
   });
 
-  it('Assesses a vulnerable prisoner', () => {
-    givenThatTheOfficerIsSignedIn();
-    whenAVulnerablePrisonerIsAssessed();
-    thenTheAssessmentIsCompleted();
+  it('Assesses a vulnerable prisoner', async function () {
+    return new Promise((resolve) => {
+      givenThatTheOfficerIsSignedIn();
+      whenAVulnerablePrisonerIsAssessed();
+      thenTheAssessmentIsCompleted(resolve);
+    });
   });
 });

--- a/test/end-to-end/browser/risk-assessment.single.cell.outcome.vulnerable.spec.js
+++ b/test/end-to-end/browser/risk-assessment.single.cell.outcome.vulnerable.spec.js
@@ -9,11 +9,9 @@ describe('Risk assessment for a vulnerable prisoner (single cell outcome)', () =
     AdminPage.loadTestUsers();
   });
 
-  it('Assesses a vulnerable prisoner', async function () {
-    return new Promise((resolve) => {
-      givenThatTheOfficerIsSignedIn();
-      whenAVulnerablePrisonerIsAssessed();
-      thenTheAssessmentIsCompleted(resolve);
-    });
-  });
+  it('Assesses a vulnerable prisoner', async () => new Promise((resolve, reject) => {
+    givenThatTheOfficerIsSignedIn();
+    whenAVulnerablePrisonerIsAssessed();
+    thenTheAssessmentIsCompleted({ resolve, reject });
+  }));
 });

--- a/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
@@ -9,6 +9,7 @@ import RiskAssessmentYesNoPage
   from '../pages/risk-assessment/RiskAssessmentYesNo.page';
 import RiskAssessmentSummaryPage
   from '../pages/risk-assessment/RiskAssessmentSummary.page';
+import db from '../../../util/db';
 
 function aLowRiskPrisonerIsAssessed(usesDrugs) {
   DashboardPage.clickRiskAssessmentStartLinkForNomisId('J1234LO');
@@ -107,12 +108,25 @@ function aSharedCellIsRecommended(sharedText) {
   );
 }
 
-function thenTheAssessmentIsCompleted() {
-  expect(DashboardPage.mainHeading).to.contain('Assessments on:');
+function thenTheAssessmentIsCompleted(resolve) {
+  expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J1234LO]');
   expect(row.getText()).to.equal(
     'John Lowe J1234LO 01-Oct-1970 Complete Start',
   );
+
+  const assessmentId = row.getAttribute('data-profile-id');
+  console.log('assessmentId2: ', assessmentId);
+
+  db.select().table('assessments').where('assessment_id', Number(assessmentId)). then(
+    (result) => {
+      console.log('results: ', result);
+      expect(result[0].nomis_id).to.equal('J1234LO');
+
+      // TODO timestamp (present), questions_hash (present), git_version (present),
+      // git_date (present), type, outcome, questions, reasons, viper
+      resolve();
+    });
 }
 
 function thenASharedCellIsRecommended() {

--- a/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
@@ -9,7 +9,7 @@ import RiskAssessmentYesNoPage
   from '../pages/risk-assessment/RiskAssessmentYesNo.page';
 import RiskAssessmentSummaryPage
   from '../pages/risk-assessment/RiskAssessmentSummary.page';
-import checkLowRiskValuesWhereWrittenToDatabase from '../db/dbAssertions';
+import checkThatAssessmentDataWasWrittenToDatabase from '../db/dbAssertions';
 
 function aLowRiskPrisonerIsAssessed(usesDrugs) {
   DashboardPage.clickRiskAssessmentStartLinkForNomisId('J1234LO');
@@ -116,9 +116,10 @@ function thenTheAssessmentIsCompleted({ resolve, reject, sharedText, reasons, ha
   );
   const assessmentId = row.getAttribute('data-risk-assessment-id');
 
-  checkLowRiskValuesWhereWrittenToDatabase({
+  checkThatAssessmentDataWasWrittenToDatabase({
     resolve,
     reject,
+    nomisId: 'J1234LO',
     assessmentId,
     questionData: {
       introduction: {

--- a/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
@@ -108,7 +108,7 @@ function aSharedCellIsRecommended(sharedText) {
   );
 }
 
-function thenTheAssessmentIsCompleted(resolve, sharedText, reasons) {
+function thenTheAssessmentIsCompleted(resolve, sharedText, reasons, hasUsedDrugs) {
   expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J1234LO]');
   expect(row.getText()).to.equal(
@@ -148,7 +148,7 @@ function thenTheAssessmentIsCompleted(resolve, sharedText, reasons) {
       'drug-misuse': {
         question_id: 'drug-misuse',
         question: 'Have they used drugs in the last month?',
-        answer: 'no',
+        answer: hasUsedDrugs ? 'yes' : 'no',
       },
       prejudice: {
         question_id: 'prejudice',

--- a/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
@@ -126,7 +126,49 @@ function thenTheAssessmentIsCompleted(resolve) {
       expect(result[0].type).to.equal('risk');
       expect(result[0].outcome).to.equal('shared cell');
       expect(result[0].reasons).to.equal('[]');
-      expect(result[0].questions).to.equal('{"introduction":{"question_id":"introduction","question":"Explain this","answer":""},"risk-of-violence":{"question_id":"risk-of-violence","question":"Viper result","answer":""},"how-do-you-feel":{"question_id":"how-do-you-feel","question":"How do you think they feel about sharing a cell at this moment?","answer":"sharing comment"},"prison-self-assessment":{"question_id":"prison-self-assessment","question":"Is there any indication they might seriously hurt a cellmate?","answer":"no"},"vulnerability":{"question_id":"vulnerability","question":"Do you think they\'re vulnerable?","answer":"no"},"gang-affiliation":{"question_id":"gang-affiliation","question":"Are they part of a gang, or likely to join a gang in prison?","answer":"no"},"drug-misuse":{"question_id":"drug-misuse","question":"Have they used drugs in the last month?","answer":"no"},"prejudice":{"question_id":"prejudice","question":"Do they have any hostile views or prejudices about a particular group?","answer":"no"},"officers-assessment":{"question_id":"officers-assessment","question":"Are there any other reasons why you would recommend they have a single cell?","answer":"no"}}');
+      expect(JSON.parse(result[0].questions)).to.eql({
+        introduction: {
+          question_id: 'introduction',
+          question: 'Explain this',
+          answer: '',
+        },
+        'risk-of-violence': { question_id: 'risk-of-violence', question: 'Viper result', answer: '' },
+        'how-do-you-feel': {
+          question_id: 'how-do-you-feel',
+          question: 'How do you think they feel about sharing a cell at this moment?',
+          answer: 'sharing comment',
+        },
+        'prison-self-assessment': {
+          question_id: 'prison-self-assessment',
+          question: 'Is there any indication they might seriously hurt a cellmate?',
+          answer: 'no',
+        },
+        vulnerability: {
+          question_id: 'vulnerability',
+          question: "Do you think they're vulnerable?",
+          answer: 'no',
+        },
+        'gang-affiliation': {
+          question_id: 'gang-affiliation',
+          question: 'Are they part of a gang, or likely to join a gang in prison?',
+          answer: 'no',
+        },
+        'drug-misuse': {
+          question_id: 'drug-misuse',
+          question: 'Have they used drugs in the last month?',
+          answer: 'no',
+        },
+        prejudice: {
+          question_id: 'prejudice',
+          question: 'Do they have any hostile views or prejudices about a particular group?',
+          answer: 'no',
+        },
+        'officers-assessment': {
+          question_id: 'officers-assessment',
+          question: 'Are there any other reasons why you would recommend they have a single cell?',
+          answer: 'no',
+        },
+      });
       expect(result[0].viper).to.equal(0.35);
       resolve();
     });

--- a/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
@@ -116,15 +116,18 @@ function thenTheAssessmentIsCompleted(resolve) {
   );
 
   const assessmentId = row.getAttribute('data-profile-id');
-  console.log('assessmentId2: ', assessmentId);
-
-  db.select().table('assessments').where('assessment_id', Number(assessmentId)). then(
+  db.select().table('assessments').where('assessment_id', Number(assessmentId)).then(
     (result) => {
-      console.log('results: ', result);
       expect(result[0].nomis_id).to.equal('J1234LO');
-
-      // TODO timestamp (present), questions_hash (present), git_version (present),
-      // git_date (present), type, outcome, questions, reasons, viper
+      expect(result[0].timestamp).to.not.equal(undefined, 'expected a timestamp');
+      expect(result[0].questions_hash).to.not.equal(undefined, 'expected a questions_hash');
+      expect(result[0].git_version).to.not.equal(undefined, 'expected a git_version');
+      expect(result[0].git_date).to.not.equal(undefined, 'expected a git_date');
+      expect(result[0].type).to.equal('risk');
+      expect(result[0].outcome).to.equal('shared cell');
+      expect(result[0].reasons).to.equal('[]');
+      expect(result[0].questions).to.equal('{"introduction":{"question_id":"introduction","question":"Explain this","answer":""},"risk-of-violence":{"question_id":"risk-of-violence","question":"Viper result","answer":""},"how-do-you-feel":{"question_id":"how-do-you-feel","question":"How do you think they feel about sharing a cell at this moment?","answer":"sharing comment"},"prison-self-assessment":{"question_id":"prison-self-assessment","question":"Is there any indication they might seriously hurt a cellmate?","answer":"no"},"vulnerability":{"question_id":"vulnerability","question":"Do you think they\'re vulnerable?","answer":"no"},"gang-affiliation":{"question_id":"gang-affiliation","question":"Are they part of a gang, or likely to join a gang in prison?","answer":"no"},"drug-misuse":{"question_id":"drug-misuse","question":"Have they used drugs in the last month?","answer":"no"},"prejudice":{"question_id":"prejudice","question":"Do they have any hostile views or prejudices about a particular group?","answer":"no"},"officers-assessment":{"question_id":"officers-assessment","question":"Are there any other reasons why you would recommend they have a single cell?","answer":"no"}}');
+      expect(result[0].viper).to.equal(0.35);
       resolve();
     });
 }

--- a/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
@@ -108,17 +108,19 @@ function aSharedCellIsRecommended(sharedText) {
   );
 }
 
-function thenTheAssessmentIsCompleted(resolve, sharedText, reasons, hasUsedDrugs) {
+function thenTheAssessmentIsCompleted({ resolve, reject, sharedText, reasons, hasUsedDrugs }) {
   expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J1234LO]');
   expect(row.getText()).to.equal(
     'John Lowe J1234LO 01-Oct-1970 Complete Start',
   );
-  const assessmentId = row.getAttribute('data-profile-id');
+  const assessmentId = row.getAttribute('data-risk-assessment-id');
 
-  checkLowRiskValuesWhereWrittenToDatabase(resolve,
+  checkLowRiskValuesWhereWrittenToDatabase({
+    resolve,
+    reject,
     assessmentId,
-    {
+    questionData: {
       introduction: {
         question_id: 'introduction',
         question: 'Explain this',
@@ -162,7 +164,8 @@ function thenTheAssessmentIsCompleted(resolve, sharedText, reasons, hasUsedDrugs
       },
     },
     reasons,
-    sharedText);
+    sharedText,
+  });
 }
 
 function thenASharedCellIsRecommended() {

--- a/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
@@ -108,7 +108,7 @@ function aSharedCellIsRecommended(sharedText) {
   );
 }
 
-function thenTheAssessmentIsCompleted(resolve) {
+function thenTheAssessmentIsCompleted(resolve, sharedText, reasons) {
   expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J1234LO]');
   expect(row.getText()).to.equal(
@@ -161,7 +161,8 @@ function thenTheAssessmentIsCompleted(resolve) {
         answer: 'no',
       },
     },
-    'shared cell');
+    reasons,
+    sharedText);
 }
 
 function thenASharedCellIsRecommended() {

--- a/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/lowRiskPrisonerAssessed.task.js
@@ -9,7 +9,7 @@ import RiskAssessmentYesNoPage
   from '../pages/risk-assessment/RiskAssessmentYesNo.page';
 import RiskAssessmentSummaryPage
   from '../pages/risk-assessment/RiskAssessmentSummary.page';
-import db from '../../../util/db';
+import checkLowRiskValuesWhereWrittenToDatabase from '../db/dbAssertions';
 
 function aLowRiskPrisonerIsAssessed(usesDrugs) {
   DashboardPage.clickRiskAssessmentStartLinkForNomisId('J1234LO');
@@ -114,64 +114,54 @@ function thenTheAssessmentIsCompleted(resolve) {
   expect(row.getText()).to.equal(
     'John Lowe J1234LO 01-Oct-1970 Complete Start',
   );
-
   const assessmentId = row.getAttribute('data-profile-id');
-  db.select().table('assessments').where('assessment_id', Number(assessmentId)).then(
-    (result) => {
-      expect(result[0].nomis_id).to.equal('J1234LO');
-      expect(result[0].timestamp).to.not.equal(undefined, 'expected a timestamp');
-      expect(result[0].questions_hash).to.not.equal(undefined, 'expected a questions_hash');
-      expect(result[0].git_version).to.not.equal(undefined, 'expected a git_version');
-      expect(result[0].git_date).to.not.equal(undefined, 'expected a git_date');
-      expect(result[0].type).to.equal('risk');
-      expect(result[0].outcome).to.equal('shared cell');
-      expect(result[0].reasons).to.equal('[]');
-      expect(JSON.parse(result[0].questions)).to.eql({
-        introduction: {
-          question_id: 'introduction',
-          question: 'Explain this',
-          answer: '',
-        },
-        'risk-of-violence': { question_id: 'risk-of-violence', question: 'Viper result', answer: '' },
-        'how-do-you-feel': {
-          question_id: 'how-do-you-feel',
-          question: 'How do you think they feel about sharing a cell at this moment?',
-          answer: 'sharing comment',
-        },
-        'prison-self-assessment': {
-          question_id: 'prison-self-assessment',
-          question: 'Is there any indication they might seriously hurt a cellmate?',
-          answer: 'no',
-        },
-        vulnerability: {
-          question_id: 'vulnerability',
-          question: "Do you think they're vulnerable?",
-          answer: 'no',
-        },
-        'gang-affiliation': {
-          question_id: 'gang-affiliation',
-          question: 'Are they part of a gang, or likely to join a gang in prison?',
-          answer: 'no',
-        },
-        'drug-misuse': {
-          question_id: 'drug-misuse',
-          question: 'Have they used drugs in the last month?',
-          answer: 'no',
-        },
-        prejudice: {
-          question_id: 'prejudice',
-          question: 'Do they have any hostile views or prejudices about a particular group?',
-          answer: 'no',
-        },
-        'officers-assessment': {
-          question_id: 'officers-assessment',
-          question: 'Are there any other reasons why you would recommend they have a single cell?',
-          answer: 'no',
-        },
-      });
-      expect(result[0].viper).to.equal(0.35);
-      resolve();
-    });
+
+  checkLowRiskValuesWhereWrittenToDatabase(resolve,
+    assessmentId,
+    {
+      introduction: {
+        question_id: 'introduction',
+        question: 'Explain this',
+        answer: '',
+      },
+      'risk-of-violence': { question_id: 'risk-of-violence', question: 'Viper result', answer: '' },
+      'how-do-you-feel': {
+        question_id: 'how-do-you-feel',
+        question: 'How do you think they feel about sharing a cell at this moment?',
+        answer: 'sharing comment',
+      },
+      'prison-self-assessment': {
+        question_id: 'prison-self-assessment',
+        question: 'Is there any indication they might seriously hurt a cellmate?',
+        answer: 'no',
+      },
+      vulnerability: {
+        question_id: 'vulnerability',
+        question: "Do you think they're vulnerable?",
+        answer: 'no',
+      },
+      'gang-affiliation': {
+        question_id: 'gang-affiliation',
+        question: 'Are they part of a gang, or likely to join a gang in prison?',
+        answer: 'no',
+      },
+      'drug-misuse': {
+        question_id: 'drug-misuse',
+        question: 'Have they used drugs in the last month?',
+        answer: 'no',
+      },
+      prejudice: {
+        question_id: 'prejudice',
+        question: 'Do they have any hostile views or prejudices about a particular group?',
+        answer: 'no',
+      },
+      'officers-assessment': {
+        question_id: 'officers-assessment',
+        question: 'Are there any other reasons why you would recommend they have a single cell?',
+        answer: 'no',
+      },
+    },
+    'shared cell');
 }
 
 function thenASharedCellIsRecommended() {

--- a/test/end-to-end/browser/tasks/prisonerWhoMayHurtSomeoneIsAssessed.task.js
+++ b/test/end-to-end/browser/tasks/prisonerWhoMayHurtSomeoneIsAssessed.task.js
@@ -37,13 +37,13 @@ function whenAPrisonerWhoMayHurtSomeoneIsAssessed() {
 }
 
 function thenASingleCellIsRecommended() {
-  expect(DashboardPage.mainHeading).to.contain('Assessments on:');
+  expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J1234LO]');
   expect(row.getText()).to.equal('John Lowe J1234LO 01-Oct-1970 Complete Start Single cell');
 }
 
 function thenTheAssessmentIsCompleted() {
-  expect(DashboardPage.mainHeading).to.contain('Assessments on:');
+  expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J1234LO]');
   expect(row.getText()).to.equal('John Lowe J1234LO 01-Oct-1970 Complete Start');
 }

--- a/test/end-to-end/browser/tasks/prisonersHealthcareResultsAreEntered.task.js
+++ b/test/end-to-end/browser/tasks/prisonersHealthcareResultsAreEntered.task.js
@@ -6,7 +6,7 @@ import HealthcareNursePage from '../pages/healthcare/HealthcareNurse.page';
 import DashboardPage from '../pages/Dashboard.page';
 import HealthcareSummary from '../pages/healthcare/HealthcareSummary.page';
 
-import checkLowRiskValuesWhereWrittenToDatabase from '../db/dbAssertions';
+import checkThatAssessmentDataWasWrittenToDatabase from '../db/dbAssertions';
 
 function aPrisonersHealthcareResultsAreEntered(singleCellRecommended) {
   DashboardPage.clickHealthcareStartLinkForNomisId('J1234LO');
@@ -67,9 +67,10 @@ function thenTheHealthcareAssessmentIsComplete({ resolve, reject, sharedText }) 
 
   const assessmentId = row.getAttribute('data-health-assessment-id');
 
-  checkLowRiskValuesWhereWrittenToDatabase({
+  checkThatAssessmentDataWasWrittenToDatabase({
     resolve,
     reject,
+    nomisId: 'J1234LO',
     assessmentId,
     assessmentType: 'healthcare',
     questionData: {
@@ -94,7 +95,6 @@ function thenTheHealthcareAssessmentIsComplete({ resolve, reject, sharedText }) 
         answer: 'Nurse, Jane Doe, 21-07-2017',
       },
     },
-    reasons: null,
     sharedText,
   });
 }

--- a/test/end-to-end/browser/tasks/prisonersHealthcareResultsAreEntered.task.js
+++ b/test/end-to-end/browser/tasks/prisonersHealthcareResultsAreEntered.task.js
@@ -1,26 +1,37 @@
 import HealthcareOutcomePage from '../pages/healthcare/HealthcareOutcome.page';
-import HealthcareCommentsPage from '../pages/healthcare/HealthcareComments.page';
+import HealthcareCommentsPage
+  from '../pages/healthcare/HealthcareComments.page';
 import HealthcareConsentPage from '../pages/healthcare/HealthcareConsent.page';
 import HealthcareNursePage from '../pages/healthcare/HealthcareNurse.page';
 import DashboardPage from '../pages/Dashboard.page';
 import HealthcareSummary from '../pages/healthcare/HealthcareSummary.page';
 
+import checkLowRiskValuesWhereWrittenToDatabase from '../db/dbAssertions';
+
 function aPrisonersHealthcareResultsAreEntered(singleCellRecommended) {
   DashboardPage.clickHealthcareStartLinkForNomisId('J1234LO');
-  expect(HealthcareOutcomePage.mainHeading).to.contain('Does healthcare recommend a single cell?');
+  expect(HealthcareOutcomePage.mainHeading).to.contain(
+    'Does healthcare recommend a single cell?',
+  );
 
   if (singleCellRecommended) {
     HealthcareOutcomePage.clickYesAndContinue();
   } else {
     HealthcareOutcomePage.clickNoAndContinue();
   }
-  expect(HealthcareCommentsPage.mainHeading).to.contain('Enter all the comments on the healthcare form');
+  expect(HealthcareCommentsPage.mainHeading).to.contain(
+    'Enter all the comments on the healthcare form',
+  );
 
   HealthcareCommentsPage.commentAndContinue('a healthcare comment');
-  expect(HealthcareConsentPage.mainHeading).to.contain('Have they given consent to share their medical information?');
+  expect(HealthcareConsentPage.mainHeading).to.contain(
+    'Have they given consent to share their medical information?',
+  );
 
   HealthcareConsentPage.clickNoAndContinue();
-  expect(HealthcareNursePage.mainHeading).to.contain('Who completed the healthcare assessment?');
+  expect(HealthcareNursePage.mainHeading).to.contain(
+    'Who completed the healthcare assessment?',
+  );
   HealthcareNursePage.enterRole('Nurse');
   HealthcareNursePage.enterName('Jane Doe');
   HealthcareNursePage.enterDate('21', '07', '2017');
@@ -32,7 +43,9 @@ function aPrisonersHealthcareResultsAreEntered(singleCellRecommended) {
   expect(HealthcareSummary.assessor).to.equalIgnoreCase('Jane Doe');
   expect(HealthcareSummary.role).to.equalIgnoreCase('nurse');
   expect(HealthcareSummary.date).to.equalIgnoreCase('21-07-2017');
-  expect(HealthcareSummary.outcome).to.equalIgnoreCase(singleCellRecommended ? 'single cell' : 'shared cell');
+  expect(HealthcareSummary.outcome).to.equalIgnoreCase(
+    singleCellRecommended ? 'single cell' : 'shared cell',
+  );
   expect(HealthcareSummary.comments).to.equalIgnoreCase('a healthcare comment');
   expect(HealthcareSummary.consent).to.equalIgnoreCase('no');
 
@@ -41,11 +54,49 @@ function aPrisonersHealthcareResultsAreEntered(singleCellRecommended) {
   expect(HealthcareSummary.consent).to.equalIgnoreCase('yes');
 }
 
-function thenTheHealthcareAssessmentIsComplete() {
+function thenTheHealthcareAssessmentIsComplete({ resolve, reject, sharedText }) {
   HealthcareSummary.clickContinue();
-  expect(DashboardPage.mainHeading).to.contain('Assessments on:');
+  expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain(
+    'Assessments on:',
+  );
+
   const row = browser.element('[data-profile-row=J1234LO]');
-  expect(row.getText()).to.equal('John Lowe J1234LO 01-Oct-1970 Start Complete');
+  expect(row.getText()).to.equal(
+    'John Lowe J1234LO 01-Oct-1970 Start Complete',
+  );
+
+  const assessmentId = row.getAttribute('data-health-assessment-id');
+
+  checkLowRiskValuesWhereWrittenToDatabase({
+    resolve,
+    reject,
+    assessmentId,
+    assessmentType: 'healthcare',
+    questionData: {
+      outcome: {
+        question_id: 'outcome',
+        question: 'Does healthcare recommend a single cell?',
+        answer: 'no',
+      },
+      comments: {
+        question_id: 'comments',
+        question: 'Enter all the comments on the healthcare form',
+        answer: 'a healthcare comment',
+      },
+      consent: {
+        question_id: 'consent',
+        question: 'Have they given consent to share their medical information?',
+        answer: 'yes',
+      },
+      assessor: {
+        question_id: 'assessor',
+        question: 'Who completed the healthcare assessment?',
+        answer: 'Nurse, Jane Doe, 21-07-2017',
+      },
+    },
+    reasons: null,
+    sharedText,
+  });
 }
 
 function whenHealthcareRecommendsSingleCell() {

--- a/test/end-to-end/browser/tasks/vulnerablePrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/vulnerablePrisonerAssessed.task.js
@@ -41,22 +41,24 @@ function whenAVulnerablePrisonerIsAssessed() {
 }
 
 function thenASingleCellIsRecommended() {
-  expect(DashboardPage.mainHeading).to.contain('Assessments on:');
+  expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J1234LO]');
   expect(row.getText()).to.equal('John Lowe J1234LO 01-Oct-1970 Complete Start Single cell');
 }
 
-function thenTheAssessmentIsCompleted(resolve) {
+function thenTheAssessmentIsCompleted({ resolve, reject }) {
   expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J1234LO]');
   expect(row.getText()).to.equal('John Lowe J1234LO 01-Oct-1970 Complete Start');
-  const assessmentId = row.getAttribute('data-profile-id');
+  const assessmentId = row.getAttribute('data-risk-assessment-id');
 
-  checkLowRiskValuesWhereWrittenToDatabase(resolve,
+  checkLowRiskValuesWhereWrittenToDatabase({
+    resolve,
+    reject,
     assessmentId,
-    {
-      introduction: {question_id: 'introduction', question: 'Explain this', answer: '' },
-      'risk-of-violence': {question_id: 'risk-of-violence', question: 'Viper result', answer: '' },
+    questionData: {
+      introduction: { question_id: 'introduction', question: 'Explain this', answer: '' },
+      'risk-of-violence': { question_id: 'risk-of-violence', question: 'Viper result', answer: '' },
       'how-do-you-feel': {
         question_id: 'how-do-you-feel',
         question: 'How do you think they feel about sharing a cell at this moment?',
@@ -67,11 +69,11 @@ function thenTheAssessmentIsCompleted(resolve) {
         question: 'Is there any indication they might seriously hurt a cellmate?',
         answer: 'no',
       },
-      vulnerability: {question_id: 'vulnerability', question: "Do you think they're vulnerable?", answer: 'yes' },
+      vulnerability: { question_id: 'vulnerability', question: "Do you think they're vulnerable?", answer: 'yes' },
     },
-    '[]',
-    'single cell',
-  )
+    reasons: '[]',
+    sharedText: 'single cell',
+  })
   ;
 }
 

--- a/test/end-to-end/browser/tasks/vulnerablePrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/vulnerablePrisonerAssessed.task.js
@@ -4,7 +4,7 @@ import RiskAssessmentExplanationPage from '../pages/risk-assessment/RiskAssessme
 import RiskAssessmentCommentsPage from '../pages/risk-assessment/RiskAssessmentComments.page';
 import RiskAssessmentYesNoPage from '../pages/risk-assessment/RiskAssessmentYesNo.page';
 import RiskAssessmentSummaryPage from '../pages/risk-assessment/RiskAssessmentSummary.page';
-import checkLowRiskValuesWhereWrittenToDatabase from '../db/dbAssertions';
+import checkThatAssessmentDataWasWrittenToDatabase from '../db/dbAssertions';
 
 function whenAVulnerablePrisonerIsAssessed() {
   DashboardPage.clickRiskAssessmentStartLinkForNomisId('J1234LO');
@@ -52,9 +52,10 @@ function thenTheAssessmentIsCompleted({ resolve, reject }) {
   expect(row.getText()).to.equal('John Lowe J1234LO 01-Oct-1970 Complete Start');
   const assessmentId = row.getAttribute('data-risk-assessment-id');
 
-  checkLowRiskValuesWhereWrittenToDatabase({
+  checkThatAssessmentDataWasWrittenToDatabase({
     resolve,
     reject,
+    nomisId: 'J1234LO',
     assessmentId,
     questionData: {
       introduction: { question_id: 'introduction', question: 'Explain this', answer: '' },
@@ -71,7 +72,6 @@ function thenTheAssessmentIsCompleted({ resolve, reject }) {
       },
       vulnerability: { question_id: 'vulnerability', question: "Do you think they're vulnerable?", answer: 'yes' },
     },
-    reasons: '[]',
     sharedText: 'single cell',
   })
   ;

--- a/test/end-to-end/browser/tasks/vulnerablePrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/vulnerablePrisonerAssessed.task.js
@@ -4,6 +4,7 @@ import RiskAssessmentExplanationPage from '../pages/risk-assessment/RiskAssessme
 import RiskAssessmentCommentsPage from '../pages/risk-assessment/RiskAssessmentComments.page';
 import RiskAssessmentYesNoPage from '../pages/risk-assessment/RiskAssessmentYesNo.page';
 import RiskAssessmentSummaryPage from '../pages/risk-assessment/RiskAssessmentSummary.page';
+import checkLowRiskValuesWhereWrittenToDatabase from '../db/dbAssertions';
 
 function whenAVulnerablePrisonerIsAssessed() {
   DashboardPage.clickRiskAssessmentStartLinkForNomisId('J1234LO');
@@ -45,10 +46,33 @@ function thenASingleCellIsRecommended() {
   expect(row.getText()).to.equal('John Lowe J1234LO 01-Oct-1970 Complete Start Single cell');
 }
 
-function thenTheAssessmentIsCompleted() {
-  expect(DashboardPage.mainHeading).to.contain('Assessments on:');
+function thenTheAssessmentIsCompleted(resolve) {
+  expect(DashboardPage.waitForMainHeadingWithDataId('dashboard')).to.contain('Assessments on:');
   const row = browser.element('[data-profile-row=J1234LO]');
   expect(row.getText()).to.equal('John Lowe J1234LO 01-Oct-1970 Complete Start');
+  const assessmentId = row.getAttribute('data-profile-id');
+
+
+  checkLowRiskValuesWhereWrittenToDatabase(resolve,
+    assessmentId,
+    {
+      introduction: {question_id: 'introduction', question: 'Explain this', answer: '' },
+      'risk-of-violence': {question_id: 'risk-of-violence', question: 'Viper result', answer: '' },
+      'how-do-you-feel': {
+        question_id: 'how-do-you-feel',
+        question: 'How do you think they feel about sharing a cell at this moment?',
+        answer: 'sharing comment',
+      },
+      'prison-self-assessment': {
+        question_id: 'prison-self-assessment',
+        question: 'Is there any indication they might seriously hurt a cellmate?',
+        answer: 'no',
+      },
+      vulnerability: {question_id: 'vulnerability', question: "Do you think they're vulnerable?", answer: 'yes' },
+    },
+    'single cell',
+  )
+  ;
 }
 
 export {

--- a/test/end-to-end/browser/tasks/vulnerablePrisonerAssessed.task.js
+++ b/test/end-to-end/browser/tasks/vulnerablePrisonerAssessed.task.js
@@ -52,7 +52,6 @@ function thenTheAssessmentIsCompleted(resolve) {
   expect(row.getText()).to.equal('John Lowe J1234LO 01-Oct-1970 Complete Start');
   const assessmentId = row.getAttribute('data-profile-id');
 
-
   checkLowRiskValuesWhereWrittenToDatabase(resolve,
     assessmentId,
     {
@@ -70,6 +69,7 @@ function thenTheAssessmentIsCompleted(resolve) {
       },
       vulnerability: {question_id: 'vulnerability', question: "Do you think they're vulnerable?", answer: 'yes' },
     },
+    '[]',
     'single cell',
   )
   ;

--- a/test/unit/server/services/assessment.spec.js
+++ b/test/unit/server/services/assessment.spec.js
@@ -91,7 +91,7 @@ describe('assessment service', () => {
 
       allows({ outcome: 'single cell' });
       allows({ outcome: 'shared cell' });
-      allows({ outcome: 'shared with conditions' });
+      allows({ outcome: 'shared cell with conditions' });
       doesNotAllow({ outcome: 'release' });
       doesNotAllow({ outcome: 'shoe' });
       doesNotAllow({ outcome: undefined }, 'missing "outcome"');

--- a/test/util/db.js
+++ b/test/util/db.js
@@ -1,0 +1,7 @@
+import knex from 'knex';
+// Ensure we use same DB setup as migrations
+import dbConfig from '../../knexfile';
+
+const db = knex(dbConfig);
+
+export default db;

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -45,7 +45,7 @@ exports.config = {
       // 5 instance gets started at a time.
       maxInstances: 5,
       //
-      browserName: 'chrome', // options: chrome || firefox || phantomjs
+      browserName: 'phantomjs', // options: chrome || firefox || phantomjs
     },
   ],
   //
@@ -60,7 +60,7 @@ exports.config = {
   sync: true,
   //
   // Level of logging verbosity: silent | verbose | command | data | result | error
-  logLevel: 'command',
+  logLevel: 'error',
   //
   // Enables colors for log output.
   coloredLogs: true,

--- a/wdio.conf.js
+++ b/wdio.conf.js
@@ -1,5 +1,4 @@
 require('dotenv').config();
-require('babel-register')();
 
 exports.config = {
   //
@@ -46,7 +45,7 @@ exports.config = {
       // 5 instance gets started at a time.
       maxInstances: 5,
       //
-      browserName: 'phantomjs', // options: chrome || firefox || phantomjs
+      browserName: 'chrome', // options: chrome || firefox || phantomjs
     },
   ],
   //
@@ -152,6 +151,8 @@ exports.config = {
   // Gets executed before test execution begins. At this point you can access all global
   // variables, such as `browser`. It is the perfect place to define custom commands.
   before(capabilities, specs) {
+    require('babel-register')();
+
     var sinon = require('sinon');
     // http://sinonjs.org/
     var chai = require('chai');


### PR DESCRIPTION
- Extend the REST API E2E test to read data back from MOCK db and assert
- Extend one of the browser based risk assessment tests to read data back from MOCK db and assert values
- Wire up the risk assessment data posting plus unit tests
- Make outcome column wider and remove work around 
- Extend one of the browser based health assessment tests to read data back from MOCK db and assert values SB
- Wire up the health assessment data posting plus unit tests
- Run subset of E2E on PROD for smoke tests