### PR TITLE
Adding iisnode.yml

### DIFF
--- a/iisnode.yml
+++ b/iisnode.yml
@@ -1,0 +1,8 @@
+# maxNamedPipeConnectionRetry - number of times IIS will retry to establish a named pipe connection with a
+# node process in order to send a new HTTP request
+
+maxNamedPipeConnectionRetry: 150
+
+# namedPipeConnectionRetryDelay - delay in milliseconds between connection retries
+
+namedPipeConnectionRetryDelay: 300


### PR DESCRIPTION
Adding iisnode.yml on the advice of Azure Support. Our app startup is
slow enough that we should delay IIS connection attepts and doing this
by increasing the number of retries and the delay between retries.